### PR TITLE
fix(system7): Chicago web font, 1080px width, fix dither moiré

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,7 @@
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
     <link href="//fonts.googleapis.com/css?family=Inconsolata:400,700&amp;subset=latin-ext,vietnamese"rel="stylesheet">
+    <link href="https://fonts.cdnfonts.com/css/chicago" rel="stylesheet">
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <!-- <link rel="stylesheet" href="{{ "/css/highlight/syntax.css" | prepend: site.baseurl }}"> -->
     <link rel="stylesheet" href="{{ "/css/highlight/rouge_monokai.css" | prepend: site.baseurl }}">

--- a/_sass/my/system7.scss
+++ b/_sass/my/system7.scss
@@ -1,65 +1,79 @@
 /* ==========================================================================
    System 7 theme overrides
-   黑白点阵桌面 / 窗口标题栏 / 立体按钮风格
    ========================================================================== */
 
-$s7-font: "ChicagoFLF", "Chicago", "Geneva", "Lucida Grande",
-          "Helvetica Neue", "Tahoma", "PingFang SC",
+/* 字体栈：Chicago 仅用于 chrome（标题栏 / 菜单栏 / 按钮 / 标题）。
+   正文用 Geneva-like 现代无衬线，避免位图字体拉伸丢失锐度。 */
+$s7-chrome: "ChicagoFLF", "Chicago", "Charcoal", "Geneva",
+            "Lucida Grande", -apple-system, BlinkMacSystemFont,
+            "Segoe UI", sans-serif;
+
+$s7-body: "Geneva", "Lucida Grande", "Helvetica Neue", -apple-system,
+          BlinkMacSystemFont, "Segoe UI", "PingFang SC",
           "Microsoft YaHei", sans-serif;
 
 $s7-mono: "Monaco", "Andale Mono", "Courier New", monospace;
 
-// 50% 点阵桌面（黑白棋盘）
-$s7-desktop: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='2' height='2' shape-rendering='crispEdges'><rect width='1' height='1' fill='%23000'/><rect x='1' y='1' width='1' height='1' fill='%23000'/></svg>");
+/* ----------- 桌面底纹 -----------
+   不再使用 50% 棋盘 dither——亚像素缩放和浏览器分辨率会产生剧烈摩尔纹。
+   改为 8x8 稀疏点阵（致敬 System 7 "Polka Dot Light" 桌面），
+   并强制 nearest-neighbor 采样保持锐边。 */
+$s7-desktop: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8' shape-rendering='crispEdges'><rect width='8' height='8' fill='%23c4c4c4'/><rect x='0' y='0' width='1' height='1' fill='%23808080'/><rect x='4' y='4' width='1' height='1' fill='%23808080'/></svg>");
 
 html {
-    background: #aaa $s7-desktop repeat;
-    background-size: 2px 2px;
+    background-color: #c4c4c4;
+    background-image: $s7-desktop;
+    background-size: 8px 8px;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    -ms-interpolation-mode: nearest-neighbor;
 }
 
 body,
 body.light-theme,
 body.dark-theme {
     background: transparent !important;
-    color: #000 !important;
-    font-family: $s7-font !important;
-    font-weight: normal !important;
-    -webkit-font-smoothing: none;
-    font-smooth: never;
-    text-rendering: geometricPrecision;
-    padding-top: 22px; // 给顶部菜单栏腾位置
+    color: #111 !important;
+    font-family: $s7-body !important;
+    font-size: 16px;
+    font-weight: 400 !important;
+    line-height: 1.55;
+    padding-top: 22px;          // 顶部菜单栏留位
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 /* ---------- 顶部菜单栏 ---------- */
 .s7-menubar {
     position: fixed;
     top: 0; left: 0; right: 0;
-    height: 20px;
+    height: 22px;
     background: #fff;
     border-bottom: 1px solid #000;
     box-shadow: 0 1px 0 #000;
     display: flex;
     align-items: center;
-    padding: 0 10px;
-    font-family: $s7-font;
-    font-size: 13px;
-    line-height: 20px;
+    padding: 0 14px;
+    font-family: $s7-chrome;
+    font-size: 14px;
+    line-height: 22px;
     z-index: 1000;
     user-select: none;
 
     .s7-apple {
-        margin-right: 18px;
-        font-size: 14px;
+        margin-right: 20px;
+        font-size: 15px;
         line-height: 1;
         cursor: default;
     }
 
     .s7-menu-item {
-        margin-right: 18px;
+        margin-right: 22px;
         color: #000 !important;
         text-decoration: none !important;
-        padding: 0 4px;
+        padding: 0 5px;
         cursor: default;
+        letter-spacing: 0.02em;
 
         &:hover {
             background: #000;
@@ -71,17 +85,18 @@ body.dark-theme {
 
     .s7-clock {
         font-variant-numeric: tabular-nums;
-        padding: 0 4px;
+        padding: 0 5px;
     }
 }
 
-/* ---------- 主容器 = 一个窗口 ---------- */
+/* ---------- 主容器 = 窗口 ---------- */
 .u-container {
     background: #fff !important;
     border: 1px solid #000 !important;
     box-shadow: 2px 2px 0 #000;
-    max-width: 760px !important;
-    margin: 30px auto 60px !important;
+    max-width: 1080px !important;
+    width: calc(100% - 48px) !important;
+    margin: 36px auto 64px !important;
     padding: 0 !important;
 }
 
@@ -99,7 +114,6 @@ body.dark-theme {
         display: flex;
         align-items: center;
         justify-content: center;
-        // 6 条水平细线（活动窗口标题栏的经典纹理）
         background-image: repeating-linear-gradient(
             to bottom,
             #000 0 1px,
@@ -110,22 +124,23 @@ body.dark-theme {
         h1 {
             background: #fff;
             color: #000 !important;
-            font-family: $s7-font !important;
-            font-size: 13px !important;
-            font-weight: normal !important;
+            font-family: $s7-chrome !important;
+            font-size: 14px !important;
+            font-weight: 400 !important;
             line-height: 1;
             margin: 0 !important;
-            padding: 0 14px;
+            padding: 0 16px;
             white-space: nowrap;
+            letter-spacing: 0.02em;
         }
     }
 
-    // 关闭框（标题栏左侧小方块）
+    // 关闭框
     &::before {
         content: "";
         position: absolute;
         top: 4px;
-        left: 6px;
+        left: 8px;
         width: 11px;
         height: 11px;
         background: #fff;
@@ -133,12 +148,12 @@ body.dark-theme {
         z-index: 2;
     }
 
-    // 缩放框（标题栏右侧小方块，嵌套方框样式）
+    // 缩放框
     &::after {
         content: "";
         position: absolute;
         top: 4px;
-        right: 6px;
+        right: 8px;
         width: 11px;
         height: 11px;
         background: #fff;
@@ -149,10 +164,10 @@ body.dark-theme {
 
     > p {
         margin: 0 !important;
-        padding: 8px 14px !important;
+        padding: 10px 18px !important;
         background: #fff;
         border-bottom: 1px solid #000;
-        font-size: 13px;
+        font-size: 14px;
         line-height: 1;
 
         a {
@@ -161,12 +176,13 @@ body.dark-theme {
             text-decoration: none !important;
             background: #fff;
             border: 1px solid #000;
-            padding: 3px 10px;
-            margin-right: 6px;
+            padding: 4px 12px;
+            margin-right: 8px;
             box-shadow: 1px 1px 0 #000;
-            font-family: $s7-font;
-            font-size: 12px;
-            line-height: 1.2;
+            font-family: $s7-chrome;
+            font-size: 13px;
+            line-height: 1.25;
+            letter-spacing: 0.02em;
 
             &:hover {
                 background: #000;
@@ -179,72 +195,75 @@ body.dark-theme {
         .u-separate { display: none; }
     }
 
-    // 隐藏明暗主题切换（System 7 是单色）
     .theme-switch { display: none !important; }
 }
 
-/* ---------- 文章/页面正文区域 ---------- */
+/* ---------- 文章/页面正文 ---------- */
 .c-article { margin-bottom: 0 !important; }
 
 .c-article__main,
 .c-article__header,
 .c-article__footer {
-    padding-left: 24px !important;
-    padding-right: 24px !important;
-    color: #000 !important;
+    padding-left: 36px !important;
+    padding-right: 36px !important;
+    color: #111 !important;
 }
 
 .c-article__header {
-    padding-top: 18px !important;
-    padding-bottom: 6px !important;
-    margin-bottom: 12px !important;
+    padding-top: 22px !important;
+    padding-bottom: 10px !important;
+    margin-bottom: 14px !important;
     border-bottom: 1px dashed #000;
 }
 
 .c-article__title {
     color: #000 !important;
-    font-family: $s7-font !important;
-    font-size: 22px !important;
-    font-weight: bold !important;
+    font-family: $s7-chrome !important;
+    font-size: 26px !important;
+    font-weight: 400 !important;
     line-height: 1.3 !important;
+    letter-spacing: 0.01em;
 }
 
 .c-article__time {
-    color: #000 !important;
-    font-size: 12px !important;
+    color: #333 !important;
+    font-family: $s7-body !important;
+    font-size: 13px !important;
 }
 
 .c-article__main {
-    font-size: 15px !important;
-    line-height: 1.55 !important;
-    color: #000 !important;
-    padding-top: 6px !important;
-    padding-bottom: 18px !important;
+    font-family: $s7-body !important;
+    font-size: 16px !important;
+    line-height: 1.65 !important;
+    color: #111 !important;
+    padding-top: 8px !important;
+    padding-bottom: 24px !important;
 
     h1, h2, h3, h4, h5, h6 {
         color: #000 !important;
-        font-family: $s7-font !important;
-        font-weight: bold !important;
-        margin-top: 1.2em;
+        font-family: $s7-chrome !important;
+        font-weight: 400 !important;
+        letter-spacing: 0.01em;
+        margin-top: 1.3em;
     }
-    h2 { font-size: 18px !important; border-bottom: 1px solid #000; padding-bottom: 2px; }
-    h3 { font-size: 16px !important; }
+    h2 { font-size: 20px !important; border-bottom: 1px solid #000; padding-bottom: 3px; }
+    h3 { font-size: 17px !important; }
     h4 { font-size: 15px !important; }
 
-    strong { color: #000 !important; font-weight: bold !important; }
+    strong { color: #000 !important; font-weight: 700 !important; }
 
     blockquote {
-        margin: 12px 0 !important;
-        padding: 8px 12px !important;
+        margin: 14px 0 !important;
+        padding: 10px 14px !important;
         background-image: repeating-linear-gradient(
             45deg,
             #fff 0 4px,
-            #ddd 4px 5px
+            #ececec 4px 5px
         );
         border: 1px solid #000 !important;
-        color: #000 !important;
+        color: #111 !important;
         font-style: normal !important;
-        font-size: 14px !important;
+        font-size: 15px !important;
         letter-spacing: 0 !important;
     }
 
@@ -258,42 +277,43 @@ body.dark-theme {
 
 /* ---------- 首页归档列表 ---------- */
 .c-archives {
-    padding: 18px 24px 8px !important;
+    padding: 22px 36px 16px !important;
     margin-bottom: 0 !important;
+    font-family: $s7-body;
 }
 
 .c-archives__year {
-    font-family: $s7-font !important;
+    font-family: $s7-chrome !important;
     font-size: 18px !important;
-    font-weight: bold !important;
-    color: #000 !important;
-    margin: 14px 0 6px !important;
-    padding: 2px 6px;
+    font-weight: 400 !important;
+    color: #fff !important;
+    margin: 18px 0 8px !important;
+    padding: 3px 10px;
     display: inline-block;
     background: #000;
-    color: #fff !important;
+    letter-spacing: 0.04em;
 }
 
 .c-archives__list { margin: 0 !important; padding: 0 !important; }
 
 .c-archives__item {
     border-top: 1px dashed #000 !important;
-    padding: 8px 0 !important;
+    padding: 10px 0 !important;
     display: flex !important;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
 
-    // 文件图标
+    // 文档图标
     &::before {
         content: "";
         display: inline-block;
         width: 12px;
         height: 14px;
-        margin-right: 8px;
+        margin-right: 10px;
         background: #fff;
         border: 1px solid #000;
-        // 文件夹/文档图标：右上角折角
         box-shadow:
             inset -3px 3px 0 #fff,
             inset -3px 3px 0 1px #000;
@@ -302,9 +322,11 @@ body.dark-theme {
 
     h3 {
         flex: 1;
-        font-size: 14px !important;
+        font-family: $s7-body !important;
+        font-size: 15px !important;
         margin: 0 !important;
-        line-height: 1.3 !important;
+        line-height: 1.35 !important;
+        font-weight: 400 !important;
 
         a {
             color: #000 !important;
@@ -318,8 +340,9 @@ body.dark-theme {
     }
 
     p {
+        font-family: $s7-body !important;
         font-size: 12px !important;
-        color: #000 !important;
+        color: #555 !important;
         margin: 0 0 0 12px !important;
     }
 }
@@ -327,20 +350,21 @@ body.dark-theme {
 /* ---------- 页脚 = 状态栏 ---------- */
 .c-page__footer {
     margin: 0 !important;
-    padding: 6px 14px !important;
+    padding: 8px 20px !important;
     background: #fff;
     border-top: 1px solid #000;
     display: block !important;
+    font-family: $s7-body;
     font-size: 12px;
 
     hr { display: none; }
 
     p {
-        color: #000 !important;
+        color: #333 !important;
         font-size: 12px !important;
         text-align: center !important;
-        margin: 2px 0 !important;
-        line-height: 1.3 !important;
+        margin: 3px 0 !important;
+        line-height: 1.4 !important;
     }
 }
 
@@ -354,9 +378,10 @@ body.dark-theme {
         border: 1px solid #000;
         background: #fff;
         color: #000 !important;
-        padding: 1px 8px;
-        margin: 2px 2px 2px 0;
+        padding: 2px 10px;
+        margin: 3px 3px 3px 0;
         box-shadow: 1px 1px 0 #000;
+        font-family: $s7-chrome;
         font-size: 12px;
         text-decoration: none !important;
 
@@ -373,6 +398,7 @@ body.dark-theme {
 a, a:visited {
     color: #000 !important;
     text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 a:hover {
@@ -391,43 +417,57 @@ pre, code {
 }
 
 pre {
-    padding: 8px 10px !important;
+    padding: 10px 12px !important;
     box-shadow: 2px 2px 0 #000;
-    font-size: 12px !important;
-    line-height: 1.5 !important;
+    font-size: 13px !important;
+    line-height: 1.55 !important;
 
     > code { box-shadow: none; border: 0 !important; }
 }
 
-code { padding: 0 3px !important; font-size: 13px !important; }
+code { padding: 1px 4px !important; font-size: 13px !important; }
 
-/* ---------- 水平分隔线 ---------- */
+/* ---------- 分隔线 ---------- */
 hr {
     border: 0;
     border-top: 1px dashed #000;
-    margin: 12px 0;
+    margin: 14px 0;
 }
 
 /* ---------- 表格 ---------- */
 table {
     border-collapse: collapse;
     border: 1px solid #000;
-    margin: 12px 0;
+    margin: 14px 0;
+    font-family: $s7-body;
 
     th, td {
         border: 1px solid #000 !important;
-        padding: 4px 8px !important;
-        font-size: 13px !important;
+        padding: 5px 10px !important;
+        font-size: 14px !important;
         background: #fff !important;
-        color: #000 !important;
+        color: #111 !important;
     }
 
     th {
         background: #000 !important;
         color: #fff !important;
-        font-weight: bold !important;
+        font-family: $s7-chrome;
+        font-weight: 400 !important;
+        letter-spacing: 0.02em;
     }
 }
 
-/* ---------- 隐藏与主题不符的元素 ---------- */
+/* ---------- 隐藏明暗切换 ---------- */
 .theme-switch { display: none !important; }
+
+/* ---------- 小屏适配 ---------- */
+@media (max-width: 720px) {
+    .u-container { width: calc(100% - 16px) !important; margin-top: 12px !important; }
+    .c-article__main,
+    .c-article__header,
+    .c-article__footer,
+    .c-archives { padding-left: 18px !important; padding-right: 18px !important; }
+    .s7-menubar { padding: 0 8px; font-size: 13px; }
+    .s7-menubar .s7-menu-item { margin-right: 12px; }
+}


### PR DESCRIPTION
Follow-up to PR #3. Addresses three issues with the System 7 theme.

## Changes

**Typography** — load Chicago FLF via `https://fonts.cdnfonts.com/css/chicago` in `_includes/head.html`. Window title bar, top menubar, buttons, tags, headings, post titles now actually render in the System 7 Chicago face. Body text switches to a clean Geneva → Lucida Grande → system sans stack for readability (bitmap fonts look bad at non-native sizes for long-form reading).

**Page width** — main "window" `max-width` 760px → 1080px, with `width: calc(100% - 48px)` safety margin. Article padding bumped accordingly. Added a 720px breakpoint to keep mobile padding sane.

**Desktop pattern moiré** — the 50% 2×2 black/white dither was guaranteed to moiré on retina + fractional browser zoom (sub-pixel interpolation). Replaced with an 8×8 sparse two-dot SVG (similar to the System 7 "Polka Dot Light" desktop pattern) plus `image-rendering: pixelated` / `-moz-crisp-edges` / `-ms-interpolation-mode: nearest-neighbor` to force nearest-neighbor sampling.

Also: minor type sizing / spacing polish, antialiasing on body.

## Files
- `_includes/head.html` — Chicago web font `<link>`
- `_sass/my/system7.scss` — fonts / width / desktop pattern / polish

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_