### PR TITLE
fix(system7): fix broken Apple logo SVG (path overflowing viewBox)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
 <body>
     <div class="s7-menubar" role="menubar">
         <div class="s7-apple-menu" tabindex="0" role="menuitem" aria-haspopup="true">
-            <span class="s7-apple" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13 16" shape-rendering="geometricPrecision"><path fill="#000" d="M8.7 0.6c-.2 1.4-1.3 2.5-2.5 2.4-.1-1.4 1.1-2.5 2.5-2.4z"/><path fill="#000" d="M11.6 11.4c-.4 1-.6 1.4-1.1 2.2-.7 1.2-1.7 2.6-3 2.6-1.1 0-1.4-.7-2.9-.7-1.5 0-1.8.7-2.9.7-1.2 0-2.2-1.3-2.9-2.4C-1 10.9-1.2 7.2.6 5.3c1.3-1.4 3.3-1.5 4.2-1.5 1 0 2.3.6 3 .6.6 0 2.1-.7 3.6-.6.6 0 2.3.2 3.4 1.8-.1.1-2 1.2-2 3.6.1 2.9 2.6 3.9 2.6 3.9-.1.1-.4 1.5-1.8 4.3z"/></svg></span>
+            <span class="s7-apple" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" shape-rendering="geometricPrecision"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5c0 26.2 4.8 53.3 14.4 81.2 12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg></span>
             <ul class="s7-apple-dropdown" role="menu">
                 <li><a href="{{ "/about/" | prepend: site.baseurl }}">About This Site...</a></li>
                 <li class="s7-divider"></li>

--- a/_sass/my/system7.scss
+++ b/_sass/my/system7.scss
@@ -525,8 +525,9 @@ table {
     display: block;
     width: 13px;
     height: 15px;
+    color: #000;                       // currentColor 驱动 SVG fill
 }
-.s7-menubar .s7-apple { line-height: 0; display: inline-flex; align-items: center; }
+.s7-menubar .s7-apple { line-height: 0; display: inline-flex; align-items: center; color: #000; }
 
 /* ---------- Apple 菜单：纯 CSS 下拉 ---------- */
 .s7-apple-menu {
@@ -539,12 +540,14 @@ table {
     cursor: default;
     outline: none;
     user-select: none;
+    color: #000;
 
     &:hover,
     &:focus,
     &:focus-within {
         background: #000;
-        .s7-apple svg path { fill: #fff !important; }
+        color: #fff;
+        .s7-apple, .s7-apple svg { color: #fff; }
     }
 }
 


### PR DESCRIPTION
## Why

In the previous round I hand-rolled the Apple-menu SVG path. The path used relative coordinates that accumulated outside the viewBox 0 0 13 16 (max x ≈ 15.4, max y ≈ 17.4, min x ≈ -1.2), so the rendered result was a clipped fragment that looked hollow / wrong — which is the "空心字 + apple logo 错" reported on the deployed v3.

## What

- Replace the broken hand-rolled path with the standard Apple silhouette path (viewBox `0 0 384 512`, fully self-contained — bounding box matches viewBox).
- Switch the SVG to `fill="currentColor"` and drive its color via the parent's `color` CSS, so the apple inherits black normally and turns white when the Apple-menu button inverts on hover/focus (previously a `fill: #fff !important` override hack).

## Files
- `_layouts/default.html` — SVG path + viewBox
- `_sass/my/system7.scss` — `.s7-apple` / `.s7-apple-menu` color cascade

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_