### PR TITLE
refine(system7): elegant typography for title bar, nav and year heading

### DIFF
--- a/_sass/my/system7.scss
+++ b/_sass/my/system7.scss
@@ -12,6 +12,12 @@ $s7-body: "Geneva", "Lucida Grande", "Helvetica Neue", -apple-system,
           BlinkMacSystemFont, "Segoe UI", "PingFang SC",
           "Microsoft YaHei", sans-serif;
 
+/* 优雅 chrome 字体：用于窗口标题 / 顶部菜单栏 / nav 按钮 / 年份等
+   不再使用位图风格的 Chicago，改用清爽的人文无衬线。 */
+$s7-elegant: "Lucida Grande", "Helvetica Neue", "Charcoal", "Geneva",
+             -apple-system, BlinkMacSystemFont, "Segoe UI",
+             "PingFang SC", system-ui, sans-serif;
+
 $s7-mono: "Monaco", "Andale Mono", "Courier New", monospace;
 
 /* ----------- 桌面底纹 -----------
@@ -53,9 +59,11 @@ body.dark-theme {
     display: flex;
     align-items: stretch;
     padding: 0 8px 0 0;
-    font-family: $s7-chrome;
-    font-size: 14px;
+    font-family: $s7-elegant;
+    font-size: 13.5px;
+    font-weight: 500;
     line-height: 22px;
+    letter-spacing: 0;
     z-index: 1000;
     user-select: none;
 
@@ -123,28 +131,24 @@ body.dark-theme {
 
     .container1 {
         position: relative;
-        height: 19px;
+        height: 24px;
         display: flex;
         align-items: center;
         justify-content: center;
-        background-image: repeating-linear-gradient(
-            to bottom,
-            #000 0 1px,
-            #fff 1px 3px
-        );
+        background: #fff;             // 不再使用横条纹底纹
         border-bottom: 1px solid #000;
 
         h1 {
-            background: #fff;
+            background: transparent;
             color: #000 !important;
-            font-family: $s7-chrome !important;
-            font-size: 14px !important;
-            font-weight: 400 !important;
+            font-family: $s7-elegant !important;
+            font-size: 13px !important;
+            font-weight: 600 !important;
             line-height: 1;
             margin: 0 !important;
             padding: 0 16px;
             white-space: nowrap;
-            letter-spacing: 0.02em;
+            letter-spacing: 0;
         }
     }
 
@@ -152,8 +156,8 @@ body.dark-theme {
     &::before {
         content: "";
         position: absolute;
-        top: 4px;
-        left: 8px;
+        top: 7px;
+        left: 10px;
         width: 11px;
         height: 11px;
         background: #fff;
@@ -167,8 +171,8 @@ body.dark-theme {
     &::after {
         content: "";
         position: absolute;
-        top: 4px;
-        right: 8px;
+        top: 7px;
+        right: 10px;
         width: 11px;
         height: 11px;
         background: #fff;
@@ -199,10 +203,11 @@ body.dark-theme {
             padding: 4px 12px;
             margin-right: 8px;
             box-shadow: 1px 1px 0 #000;
-            font-family: $s7-chrome;
+            font-family: $s7-elegant;
             font-size: 13px;
+            font-weight: 500;
             line-height: 1.25;
-            letter-spacing: 0.02em;
+            letter-spacing: 0;
 
             &:hover {
                 background: #000;
@@ -303,24 +308,25 @@ body.dark-theme {
 }
 
 .c-archives__year {
-    font-family: $s7-chrome !important;
-    font-size: 18px !important;
-    font-weight: 400 !important;
-    color: #fff !important;
-    background: #000 !important;
-    margin: 18px 0 8px !important;
-    padding: 3px 10px !important;
-    display: inline-block;
-    letter-spacing: 0.04em;
-    border-bottom: none !important;     // 撤掉来自 .c-article__main h2 的下划线
+    font-family: $s7-elegant !important;
+    font-size: 22px !important;
+    font-weight: 600 !important;
+    color: #000 !important;
+    background: transparent !important;
+    margin: 28px 0 12px !important;
+    padding: 0 0 6px 0 !important;
+    display: block;
+    border-bottom: 2px solid #000 !important;
+    letter-spacing: 0;
 }
 
-// 同时在 .c-article__main 内部明确覆盖，确保赢过 `.c-article__main h2` 的颜色规则
+// 显式覆盖 `.c-article__main h2` 的样式，避免被吃掉
 .c-article__main .c-archives__year {
-    color: #fff !important;
-    background: #000 !important;
-    border-bottom: none !important;
-    padding-bottom: 3px !important;
+    color: #000 !important;
+    background: transparent !important;
+    border-bottom: 2px solid #000 !important;
+    padding: 0 0 6px 0 !important;
+    font-family: $s7-elegant !important;
 }
 
 .c-archives__list { margin: 0 !important; padding: 0 !important; }
@@ -563,9 +569,9 @@ table {
     border: 1px solid #000;
     box-shadow: 1px 1px 0 #000;
     min-width: 200px;
-    font-family: $s7-chrome;
+    font-family: $s7-elegant;
     font-size: 13px;
-    line-height: 1.4;
+    line-height: 1.45;
     z-index: 1100;
 
     li { margin: 0; padding: 0; list-style: none; }


### PR DESCRIPTION
## Why

User feedback: 不要点阵子（title, nav, 年份）请优化 — the bitmap / dot-matrix aesthetic feels too rough on three specific chrome areas. Use elegant typography there instead.

## What

- New `$s7-elegant` font stack (Lucida Grande → Helvetica Neue → Charcoal → Geneva → -apple-system / Segoe UI / system-ui) and apply it to:
  - the window **title bar** `h1`
  - the **top menubar** items + Apple dropdown
  - the in-page **nav buttons** (Back / Home / Timeline / Tags / About)
  - the archives **year heading**
- Drop the 6-stripe horizontal pattern from the window title bar; use a clean white bar with a 1px black bottom border instead (System 7 active-window stripes were the very pattern the user wants gone here).
- Title bar height 19px → 24px (more breathing room for the elegant text); close / zoom boxes nudged to `top: 7px` so they stay vertically centered.
- Archives year: drop the heavy filled-black chip; replace with a 600-weight 22px heading with a 2px black bottom border. Reads as a refined section divider rather than a chunky pill.
- Buttons / tags / post titles / article H2 etc. still keep the Chicago stack — that bitmap character is still part of the System 7 charm where it lives at small fixed sizes.

## Files
- `_sass/my/system7.scss` only

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_