### PR TITLE
security: remove compromised polyfill.io script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,7 +12,6 @@
     <link rel="stylesheet" href="{{ "/css/highlight/rouge_monokai.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     {% include amplinking.html %}
     {% include googleanalytics.html %}


### PR DESCRIPTION
## ⚠️ Security: drop the compromised polyfill.io script

`_includes/head.html` was loading:

```html
<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
```

In **June 2024**, the `polyfill.io` domain was sold to Funnull, and the new operator immediately began injecting malicious code into requests served from the original CDN — mobile redirects, ad/malvertising injection, and (as reported by the site owner) an unexpected HTTP-basic-auth prompt:

> *https://polyfill.io requires a username and password.*

…that pops up on **every page navigation**. Cloudflare, Fastly, Google, and the original author (Andrew Betts) all publicly recommended removing it; many CDNs blocklisted the domain.

### Why simply delete (no replacement)

The script was added years ago via MathJax's getting-started snippet to polyfill ES6 for legacy browsers. ES6 has shipped natively in every mainstream browser since ~2017 and MathJax v3 does not require it on current browser targets. The inline `MathJax = {...}` config and the MathJax v3 `<script>` immediately below it continue to work without it.

If we ever need the polyfill again for an ancient browser, the safe drop-in replacement would be Cloudflare's mirror: `https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6`.

## Verification

- After this deploys, hard-refresh the live blog and confirm the "Sign in / polyfill.io requires a username and password" dialog no longer appears.
- DevTools → Network: no request to `polyfill.io`.
- MathJax-rendered formulas still typeset.

## Files
- `_includes/head.html` — single line removed

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_