### PR TITLE
chore: bump build marker to retrigger Pages deploy

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -1,5 +1,6 @@
 ---
 # Main scss file
+# build: 2026-06-21
 ---
 @charset "UTF-8";
 


### PR DESCRIPTION
Trivial chore to nudge GitHub Pages into rebuilding — the previous merge (PR #13: mobile + Timeline fix) doesn't appear to have triggered a deploy.

## What
- Added a dated comment to `css/main.scss`'s Jekyll front-matter (`# build: 2026-06-21`).

Front-matter comments are not emitted into the built CSS, so output is byte-identical to the previous build. The only purpose is to make Pages see a content change and re-run the build.

## Verification
- After merge, watch the **Actions** tab (or the repo's *Environments → github-pages*) for a fresh `pages-build-deployment` run.
- Once it goes green, hard-refresh the live site on mobile to confirm the prior fixes (16 px body, compact Timeline ledger) are now visible.

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_