### PR TITLE
fix(code): kill line-numbers + neutralize nested pre padding

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,7 @@ kramdown:
     span:
       line_numbers: false
     block:
-      line_numbers: true
-      start_line: 1
-      theme: solarized
+      line_numbers: false
 
 future: true
 permalink: /:year/:month/:title

--- a/_sass/my/inkstone.scss
+++ b/_sass/my/inkstone.scss
@@ -429,17 +429,79 @@ code {
     border-radius: 3px !important;
     padding: 0.1em 0.4em !important;
 }
+
+/* Single outer code block ——
+   Only the top-level pre carries padding/border so nested rouge
+   structures (figure > pre > code > pre, or table-based line-numbers)
+   never compound spacing. */
 pre {
     background: $wash !important;
     color: $ink !important;
     border: 0 !important;
     border-left: 2px solid $line !important;
     border-radius: 0 !important;
-    padding: 1.1rem 1.3rem !important;
-    line-height: 1.6 !important;
-    overflow-x: auto;
+    padding: 1rem 1.2rem !important;
+    line-height: 1.55 !important;
+    overflow-x: auto !important;
     box-shadow: none !important;
-    > code { background: transparent !important; padding: 0 !important; border: 0 !important; }
+    margin: 1.4rem 0 !important;
+}
+pre > code,
+pre code,
+pre pre,
+.highlight pre,
+.highlight code,
+.highlighter-rouge pre,
+.highlighter-rouge code,
+figure.highlight pre,
+figure.highlight code {
+    background: transparent !important;
+    border: 0 !important;
+    border-left: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+}
+
+/* Defensive: if any legacy post still emits the rouge line-numbers
+   <table>, render it tightly instead of with table-cell spacing. */
+.highlight table,
+.highlighter-rouge table,
+figure.highlight table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0;
+    background: transparent;
+}
+.highlight table td,
+.highlighter-rouge table td,
+figure.highlight table td {
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+    vertical-align: top;
+}
+.highlight td.gutter,
+.highlight td.gl,
+.highlighter-rouge td.gutter,
+.highlighter-rouge td.gl {
+    width: 1%;                           /* shrink to content */
+    padding-right: 0.9em !important;
+    border-right: 1px solid $line !important;
+    margin-right: 0.9em !important;
+    color: $mist !important;
+    user-select: none;
+    text-align: right;
+}
+.highlight td.code,
+.highlighter-rouge td.code {
+    padding-left: 0.9em !important;
+    width: auto;
+}
+.highlight .lineno {
+    color: $mist !important;
+    user-select: none;
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Mobile screenshot showed a code block with a huge empty column between the line numbers and the code, plus right-side overflow cutting off comments. Two root causes:

1. `_config.yml` had kramdown's `block.line_numbers: true`, so every fenced code block was rendered as a `<table>` with a gutter `<td>` and a code `<td>`, **both wrapped in nested `<pre>` elements**. My `pre { padding: 1.1rem 1.3rem }` rule applied to all three nested `<pre>`s, **compounding into ~3 rem of dead whitespace** and shoving real code off the right edge.
2. Line numbers themselves waste ~40% of the viewport on a phone for almost no reader value — they conflict with the Inkstone minimalist brief.

## What

- **`_config.yml`** — `block.line_numbers: false`. Future builds emit clean `<pre><code>…</code></pre>` with zero scaffolding.
- **`_sass/my/inkstone.scss`** — defensive CSS so this can never regress:
  - Only the **top-level** `<pre>` carries padding / border / margin.
  - Any nested `pre`, `code`, or rouge-wrapper combination (`pre code`, `.highlight pre`, `.highlighter-rouge code`, `figure.highlight pre`, …) is fully zeroed.
  - For old posts whose cached HTML still has the rouge line-numbers `<table>`, the table renders tightly: `1%` width gutter, `border-right: 1px solid` divider, `0.9em` gap, no table-cell padding bleed.
  - `pre` now declares `overflow-x: auto !important` and `margin: 1.4rem 0 !important` so it scrolls cleanly and doesn't collapse with surrounding paragraphs.

## Verification

- Compiles with dart-sass (compressed, 24.6 KB). Built CSS contains the nested-pre zero-out rule + the gutter/table rule.
- New posts will render as a single clean panel with no line-number column.

## Files
- `_config.yml`
- `_sass/my/inkstone.scss`

Commit in this PR:
- `221370d` — kill line-numbers, neutralize nested pre padding

https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3

---
_Generated by [Claude Code](https://claude.ai/code/session_013Av5LoGbFkxdcBuVfJGSE3)_